### PR TITLE
#26 Allow to download schema from http(s)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
       <version>${json-schema-validator-version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.13</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/src/it/multiple-validation-sets/pom.xml
+++ b/src/it/multiple-validation-sets/pom.xml
@@ -38,6 +38,12 @@
                     <include>src/main/resources/malformed.yml</include>
                   </includes>
                 </validationSet>
+                <validationSet>
+                  <jsonSchema>https://swagger.io/v2/schema.json</jsonSchema>
+                  <includes>
+                    <include>src/main/resources/swagger-editor-example.yml</include>
+                  </includes>
+                </validationSet>
               </validationSets>
             </configuration>
           </execution>

--- a/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojo.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojo.java
@@ -1,5 +1,6 @@
 package com.github.sylvainlaurent.maven.yamljsonvalidator;
 
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -138,7 +139,9 @@ public class ValidateMojo extends AbstractMojo {
                     try (final CloseableHttpClient httpclient = HttpClients.custom().useSystemProperties().build()) {
                         HttpGet get = new HttpGet();
                         get.setURI(uri);
-                        return httpclient.execute(get).getEntity().getContent();
+                        try (CloseableHttpResponse response = httpclient.execute(get)) {
+                            return response.getEntity().getContent();
+                        }
                     }
                 }
             } catch (URISyntaxException | IOException use) {

--- a/src/test/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojoTest.java
+++ b/src/test/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojoTest.java
@@ -23,6 +23,12 @@ public class ValidateMojoTest {
         assertNotNull(validateMojo.openJsonSchema("src/test/resources/schema-with-ref.json"));
     }
 
+    @Test
+    public void accept_schema_from_http() throws MojoExecutionException {
+        ValidateMojo validateMojo = new ValidateMojo();
+        assertNotNull(validateMojo.openJsonSchema("https://json.schemastore.org/geojson.json"));
+    }
+
 
     @Test
     public void accept_schema_from_classpath() throws MojoExecutionException {


### PR DESCRIPTION
I simply added the ability to download schemas from http using apache's HttpClient. This HttpClient can be configured using the system properties so it is possible to configure SSL, proxies, etc. this way.
I also added unit and integration tests.