### PR TITLE
Skip non-existing base directory and other updates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M6</version>
+          <version>3.0.0-M7</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <json-schema-validator-version>2.2.14</json-schema-validator-version>
-    <jackson-version>2.11.2</jackson-version>
+    <jackson-version>2.13.3</jackson-version>
   </properties>
 
   <dependencies>
@@ -59,7 +59,18 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.3.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-compat</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -83,7 +94,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.30</version>
+      <version>1.7.36</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -100,9 +111,14 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.7.0</version>
+        <version>5.8.2</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-classworlds</artifactId>
+        <version>2.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -113,7 +129,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
@@ -122,7 +138,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M6</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -205,7 +221,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>enforce-versions</id>

--- a/pom.xml
+++ b/pom.xml
@@ -267,5 +267,22 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java9+</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>8</release>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>integration-test</id>

--- a/src/it/skip-nonexisting-basedir/invoker.properties
+++ b/src/it/skip-nonexisting-basedir/invoker.properties
@@ -1,0 +1,1 @@
+invoker.buildResult = success

--- a/src/it/skip-nonexisting-basedir/pom.xml
+++ b/src/it/skip-nonexisting-basedir/pom.xml
@@ -26,13 +26,11 @@
               <goal>validate</goal>
             </goals>
             <configuration>
-              <detectDuplicateKeys>false</detectDuplicateKeys>
               <validationSets>
                 <validationSet>
-                  <baseDir>src</baseDir>
-                  <jsonSchema>main/resources/swagger-schema.json</jsonSchema>
+                  <baseDir>${project.basedir}/doesnotexist</baseDir>
                   <includes>
-                    <include>main/resources/swagger-*.yml</include>
+                    <include>src/main/resources/*.yml</include>
                   </includes>
                 </validationSet>
               </validationSets>

--- a/src/it/skip-nonexisting-basedir/verify.groovy
+++ b/src/it/skip-nonexisting-basedir/verify.groovy
@@ -1,0 +1,2 @@
+return new File('target/it/skip-nonexisting-basedir/build.log')
+        .text.contains('does not exist or is not a directory. Skipping.')

--- a/src/it/validate-succeeds/verify.groovy
+++ b/src/it/validate-succeeds/verify.groovy
@@ -1,0 +1,2 @@
+return !(new File('target/it/validate-succeeds/build.log')
+        .text.contains('does not exist or is not a directory. Skipping.'))

--- a/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojo.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojo.java
@@ -29,7 +29,7 @@ public class ValidateMojo extends AbstractMojo {
      * and <code>&lt;exclude&gt;</code> elements respectively to specify lists of file masks of
      * included and excluded files. The file masks are treated as paths relative to
      * <code>${project.basedir}</code> and their syntax is that of
-     * <code>org.codehaus.plexus.util.DirectoryScanner</code>.</p>
+     * <code>org.apache.maven.shared.utils.io.DirectoryScanner</code>.</p>
      *
      * <p>JSON schema can be specified with <code>&lt;jsonSchema&gt;</code> element.</p>
      */
@@ -70,6 +70,12 @@ public class ValidateMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean allowTrailingComma;
 
+    /**
+     * Set to <code>true</code> to follow symlinks.
+     */
+    @Parameter(defaultValue = "true")
+    private boolean followSymlinks;
+
     @Override
     public void execute() throws MojoExecutionException {
         boolean encounteredError = false;
@@ -88,7 +94,7 @@ public class ValidateMojo extends AbstractMojo {
                     allowJsonComments,
                     allowTrailingComma);
 
-            final File[] files = set.getFiles(basedir);
+            final File[] files = ValidationSet.getFiles(set, basedir, followSymlinks);
 
             for (final File file : files) {
                 if (verbose) {

--- a/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojo.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidateMojo.java
@@ -76,6 +76,13 @@ public class ValidateMojo extends AbstractMojo {
     @Parameter(defaultValue = "true")
     private boolean followSymlinks;
 
+    /**
+     * Set to <code>true</code> to include default excludes. Default excludes contain excludes for backup files and
+     * SCM directories.
+     */
+    @Parameter(defaultValue = "true")
+    private boolean addDefaultExcludes;
+
     @Override
     public void execute() throws MojoExecutionException {
         boolean encounteredError = false;
@@ -94,7 +101,7 @@ public class ValidateMojo extends AbstractMojo {
                     allowJsonComments,
                     allowTrailingComma);
 
-            final File[] files = ValidationSet.getFiles(set, basedir, followSymlinks);
+            final File[] files = ValidationSet.getFiles(set, basedir, followSymlinks, addDefaultExcludes);
 
             for (final File file : files) {
                 if (verbose) {

--- a/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidationService.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidationService.java
@@ -1,6 +1,7 @@
 package com.github.sylvainlaurent.maven.yamljsonvalidator;
 
 import com.fasterxml.jackson.core.JsonParser.Feature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.MissingNode;
@@ -41,8 +42,8 @@ public class ValidationService {
             this.jsonMapper.enable(Feature.ALLOW_COMMENTS);
         }
         if (allowTrailingComma) {
-            this.jsonMapper.enable(Feature.ALLOW_TRAILING_COMMA);
-            this.yamlMapper.enable(Feature.ALLOW_TRAILING_COMMA);
+            this.jsonMapper.enable(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature());
+            this.yamlMapper.enable(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature());
         }
     }
 

--- a/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidationSet.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidationSet.java
@@ -1,8 +1,8 @@
 package com.github.sylvainlaurent.maven.yamljsonvalidator;
 
-import java.io.File;
+import org.apache.maven.shared.utils.io.DirectoryScanner;
 
-import org.codehaus.plexus.util.DirectoryScanner;
+import java.io.File;
 
 public class ValidationSet {
     /**
@@ -38,14 +38,15 @@ public class ValidationSet {
         this.excludes = excludes;
     }
 
-    public File[] getFiles(final File basedir) {
+    public static File[] getFiles(final ValidationSet validationSet, final File basedir, boolean followSymlinks) {
         final DirectoryScanner ds = new DirectoryScanner();
         ds.setBasedir(basedir);
-        if (includes != null && includes.length > 0) {
-            ds.setIncludes(includes);
+        ds.setFollowSymlinks(followSymlinks);
+        if (validationSet.includes != null && validationSet.includes.length > 0) {
+            ds.setIncludes(validationSet.includes);
         }
-        if (excludes != null && excludes.length > 0) {
-            ds.setExcludes(excludes);
+        if (validationSet.excludes != null && validationSet.excludes.length > 0) {
+            ds.setExcludes(validationSet.excludes);
         }
         ds.scan();
         final String[] filePaths = ds.getIncludedFiles();

--- a/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidationSet.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/yamljsonvalidator/ValidationSet.java
@@ -38,10 +38,14 @@ public class ValidationSet {
         this.excludes = excludes;
     }
 
-    public static File[] getFiles(final ValidationSet validationSet, final File basedir, boolean followSymlinks) {
+    public static File[] getFiles(final ValidationSet validationSet, final File basedir, final boolean followSymlinks,
+                                  final boolean addDefaultExcludes) {
         final DirectoryScanner ds = new DirectoryScanner();
         ds.setBasedir(basedir);
         ds.setFollowSymlinks(followSymlinks);
+        if (addDefaultExcludes) {
+            ds.addDefaultExcludes();
+        }
         if (validationSet.includes != null && validationSet.includes.length > 0) {
             ds.setIncludes(validationSet.includes);
         }


### PR DESCRIPTION
There are some updates here in the branch. But the main change here is the addition of `baseDir` configuration to the validation set. This allows me to speed up execution of the checking goal when it is set up in parent of huge Maven projects tree. When such tree has many many files, like several `node_modules` directories, the directory scanning code goes through all of the files and never finds a matching file to verify. But with the `baseDir` options, if I set the value to, say, `${project.basedir}/src`, I can return from the scanning code immediately and avoid scanning the entire tree without results.